### PR TITLE
Add AS_HELP_STRING to *nix build configure options

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -1,5 +1,7 @@
-PHP_ARG_ENABLE(fiber, whether to enable fiber support,
-[  --enable-fiber          Enable fiber fiber support], no)
+PHP_ARG_ENABLE([fiber],
+  [whether to enable fiber support],
+  [AS_HELP_STRING([--enable-fiber],
+    [Enable fiber support])], [no])
 
 if test "$PHP_FIBER" != "no"; then
   AC_DEFINE(HAVE_FIBER, 1, [ ])


### PR DESCRIPTION
The Autoconf's default AS_HELP_STRING macro can properly format help
strings [1] so watching out if columns are aligned manually is not
anymore.

[1] https://www.gnu.org/software/autoconf/manual/autoconf.html#Pretty-Help-Strings