### PR TITLE
Fix Windows build

### DIFF
--- a/boost/asm/jump_x86_64_ms_pe_masm.asm
+++ b/boost/asm/jump_x86_64_ms_pe_masm.asm
@@ -84,7 +84,7 @@
 
 .code
 
-jump_fcontext PROC BOOST_CONTEXT_EXPORT FRAME
+jump_fcontext PROC EXPORT FRAME
     .endprolog
 
     ; prepare stack

--- a/boost/asm/make_x86_64_ms_pe_masm.asm
+++ b/boost/asm/make_x86_64_ms_pe_masm.asm
@@ -87,7 +87,7 @@ EXTERN  _exit:PROC
 .code
 
 ; generate function table entry in .pdata and unwind information in
-make_fcontext PROC BOOST_CONTEXT_EXPORT FRAME
+make_fcontext PROC EXPORT FRAME
     ; .xdata for a function's structured exception handling unwind behavior
     .endprolog
 

--- a/config.w32
+++ b/config.w32
@@ -11,21 +11,17 @@ if (PHP_FIBER != 'no') {
 	for (var i = 0; i < ASM_FILENAMES.length; ++i) {
 	    var filename = ASM_FILENAMES[i];
 		var src = (configure_module_dirname + '\\' + ASM_DIR + '\\' + filename + '.asm').replace(/\//g, '\\');
-		var obj = '$(BUILD_DIR)\\' + filename + '.obj';
+		var obj = '$(BUILD_DIR)\\src\\' + filename + '.obj';
 
 		MFO.WriteLine(obj + ': ' + src);
-		// var objdir = obj.replace(/\\[^\\]+$/, "");
-		// MFO.WriteLine('\t@IF NOT EXIST ' + objdir + ' MKDIR ' + objdir);
 		MFO.WriteLine('\t@$(FIBER_ASSEMBLER) /Fo' + obj + ' /c ' + src);
+		MFO.WriteLine('$(BUILD_DIR)\\php_fiber.dll: ' + obj);
 	}
 
 	var FIBER_SOURCES = 'src\\php_fiber.c src\\fiber.c src\\fiber_asm.c src\\fiber_stack.c';
 	EXTENSION('fiber', FIBER_SOURCES, null, '/I. /Iinclude /DZEND_ENABLE_STATIC_TSRMLS_CACHE=1  /DPHP_FIBER_EXPORTS=1');
 
-	var OBJ_FILENAMES = [];
 	for (var i = 0; i < ASM_FILENAMES.length; ++i) {
-		OBJ_FILENAMES.push(ASM_FILENAMES[i] + '.obj');
+		ADD_FLAG('LDFLAGS_FIBER', '$(BUILD_DIR)\\src\\' + ASM_FILENAMES[i] + '.obj ');
 	}
-	
-	ADD_SOURCES(configure_module_dirname + '\\' + ASM_DIR, OBJ_FILENAMES.join(' '), 'fiber');
 }

--- a/config.w32
+++ b/config.w32
@@ -3,5 +3,29 @@ ARG_ENABLE('fiber', 'fiber support', 'yes');
 if (PHP_FIBER != 'no') {
 	AC_DEFINE('HAVE_FIBER', 1, 'fiber support enabled');
 
-	EXTENSION('fiber', 'src\\php_fiber.c src\\fiber.c src\\fiber_winfib.c', null, '/I. /Iinclude /DZEND_ENABLE_STATIC_TSRMLS_CACHE=1  /DPHP_FIBER_EXPORTS=1');
+	var FIBER_ASSEMBLER = PATH_PROG('ML64');
+
+	DEFINE('FIBER_ASSEMBLER', FIBER_ASSEMBLER);
+	var ASM_DIR = 'boost\\asm';
+	var ASM_FILENAMES = ['jump_x86_64_ms_pe_masm', 'make_x86_64_ms_pe_masm'];
+	for (var i = 0; i < ASM_FILENAMES.length; ++i) {
+	    var filename = ASM_FILENAMES[i];
+		var src = (configure_module_dirname + '\\' + ASM_DIR + '\\' + filename + '.asm').replace(/\//g, '\\');
+		var obj = '$(BUILD_DIR)\\' + filename + '.obj';
+
+		MFO.WriteLine(obj + ': ' + src);
+		// var objdir = obj.replace(/\\[^\\]+$/, "");
+		// MFO.WriteLine('\t@IF NOT EXIST ' + objdir + ' MKDIR ' + objdir);
+		MFO.WriteLine('\t@$(FIBER_ASSEMBLER) /Fo' + obj + ' /c ' + src);
+	}
+
+	var FIBER_SOURCES = 'src\\php_fiber.c src\\fiber.c src\\fiber_asm.c src\\fiber_stack.c';
+	EXTENSION('fiber', FIBER_SOURCES, null, '/I. /Iinclude /DZEND_ENABLE_STATIC_TSRMLS_CACHE=1  /DPHP_FIBER_EXPORTS=1');
+
+	var OBJ_FILENAMES = [];
+	for (var i = 0; i < ASM_FILENAMES.length; ++i) {
+		OBJ_FILENAMES.push(ASM_FILENAMES[i] + '.obj');
+	}
+	
+	ADD_SOURCES(configure_module_dirname + '\\' + ASM_DIR, OBJ_FILENAMES.join(' '), 'fiber');
 }

--- a/src/fiber_stack.c
+++ b/src/fiber_stack.c
@@ -25,15 +25,9 @@
 
 zend_bool zend_fiber_stack_allocate(zend_fiber_stack *stack, unsigned int size)
 {
-	static __thread size_t page_size;
-
-	if (!page_size) {
-		page_size = ZEND_FIBER_PAGESIZE;
-	}
-
 	size_t msize;
 
-	stack->size = ((size_t) size + page_size - 1) / page_size * page_size;
+	stack->size = ((size_t) size + ZEND_FIBER_PAGESIZE - 1) / ZEND_FIBER_PAGESIZE * ZEND_FIBER_PAGESIZE;
 
 #ifdef ZEND_FIBER_MMAP
 
@@ -43,7 +37,7 @@ zend_bool zend_fiber_stack_allocate(zend_fiber_stack *stack, unsigned int size)
 	mapflags |= MAP_STACK;
 #endif
 
-	msize = stack->size + ZEND_FIBER_GUARD_PAGES * page_size;
+	msize = stack->size + ZEND_FIBER_GUARD_PAGES * ZEND_FIBER_PAGESIZE;
 	pointer = mmap(0, msize, PROT_READ | PROT_WRITE, mapflags, -1, 0);
 
 	if (pointer == (void *) -1) {
@@ -51,10 +45,10 @@ zend_bool zend_fiber_stack_allocate(zend_fiber_stack *stack, unsigned int size)
 	}
 
 #if ZEND_FIBER_GUARD_PAGES
-	mprotect(pointer, ZEND_FIBER_GUARD_PAGES * page_size, PROT_NONE);
+	mprotect(pointer, ZEND_FIBER_GUARD_PAGES * ZEND_FIBER_PAGESIZE, PROT_NONE);
 #endif
 
-	stack->pointer = (void *)((char *) pointer + ZEND_FIBER_GUARD_PAGES * page_size);
+	stack->pointer = (void *)((char *) pointer + ZEND_FIBER_GUARD_PAGES * ZEND_FIBER_PAGESIZE);
 #else
 	stack->pointer = emalloc_large(stack->size);
 	msize = stack->size;
@@ -68,7 +62,7 @@ zend_bool zend_fiber_stack_allocate(zend_fiber_stack *stack, unsigned int size)
 	char * base;
 
 	base = (char *) stack->pointer;
-	stack->valgrind = VALGRIND_STACK_REGISTER(base, base + msize - ZEND_FIBER_GUARD_PAGES * page_size);
+	stack->valgrind = VALGRIND_STACK_REGISTER(base, base + msize - ZEND_FIBER_GUARD_PAGES * ZEND_FIBER_PAGESIZE);
 #endif
 
 	return 1;
@@ -76,12 +70,6 @@ zend_bool zend_fiber_stack_allocate(zend_fiber_stack *stack, unsigned int size)
 
 void zend_fiber_stack_free(zend_fiber_stack *stack)
 {
-	static __thread size_t page_size;
-
-	if (!page_size) {
-		page_size = ZEND_FIBER_PAGESIZE;
-	}
-
 	if (stack->pointer != NULL) {
 #ifdef VALGRIND_STACK_DEREGISTER
 		VALGRIND_STACK_DEREGISTER(stack->valgrind);
@@ -92,8 +80,8 @@ void zend_fiber_stack_free(zend_fiber_stack *stack)
 		void *address;
 		size_t len;
 
-		address = (void *)((char *) stack->pointer - ZEND_FIBER_GUARD_PAGES * page_size);
-		len = stack->size + ZEND_FIBER_GUARD_PAGES * page_size;
+		address = (void *)((char *) stack->pointer - ZEND_FIBER_GUARD_PAGES * ZEND_FIBER_PAGESIZE);
+		len = stack->size + ZEND_FIBER_GUARD_PAGES * ZEND_FIBER_PAGESIZE;
 
 		munmap(address, len);
 #else


### PR DESCRIPTION
This is a super hacky solution, but should work for any shared builds.
First we need to fix the obj filenames, since these are expected in the
src/ subfolder.  To trigger their compilation, we write the required
dependency rules manually to the Makefile.  Finally we add the assembler
obj files as LD_FLAGS.

A clean solution would be to support asm files as source files in the
Windows build chain.  If that does not happen, at least we should use
a Makefile.fragment, to avoid the dependency on `MFO`.  We also should
strive to minimize the use of global variables in config.w32.